### PR TITLE
Make async token refresh mechanism

### DIFF
--- a/Modules/Sources/APIClient/Client.swift
+++ b/Modules/Sources/APIClient/Client.swift
@@ -13,16 +13,16 @@ import XCTestDynamicOverlay
 /// Interface for all network calls
 public struct APIClient {
 
-    public var authenticate: (Username, Password) -> AnyPublisher<APITokens, APIError>
-    public var refreshToken: (RefreshToken) -> AnyPublisher<APITokens, APIError>
-    public var setToken: (APITokens) -> Void
+    public var authenticate: (Username, Password) async throws -> APITokensEnvelope
+    public var refreshToken: (RefreshToken)  async throws -> APITokensEnvelope
+    public var setToken: (APITokensEnvelope) -> Void
     public var setBaseURL: (URL) -> Void
     public var currentBaseURL: () -> URL
 
     public init(
-        authenticate: @escaping (Username, Password) -> AnyPublisher<APITokens, APIError>,
-        refreshToken: @escaping (RefreshToken) -> AnyPublisher<APITokens, APIError>,
-        setToken: @escaping (APITokens) -> Void,
+        authenticate: @escaping (Username, Password) async throws -> APITokensEnvelope,
+        refreshToken: @escaping (RefreshToken)  async throws -> APITokensEnvelope,
+        setToken: @escaping (APITokensEnvelope) -> Void,
         setBaseURL: @escaping (URL) -> Void,
         currentBaseURL: @escaping () -> URL
     ) {
@@ -36,9 +36,9 @@ public struct APIClient {
 }
 
 extension APIClient {
-    public static let failing = Self(
-        authenticate: { _, _ in .failing("\(Self.self).authenticate failing endpoint called") },
-        refreshToken: { _ in .failing("\(Self.self).refreshToken failing endpoint called") },
+    public static let failing = APIClient(
+        authenticate: XCTUnimplemented("authenticate failing endpoint called"),
+        refreshToken: XCTUnimplemented("\(Self.self).refreshToken failing endpoint called") ,
         setToken: { _ in XCTFail("\(Self.self).setToken failing endpoint called") },
         setBaseURL: { _ in fatalError() },
         currentBaseURL: { fatalError() }

--- a/Modules/Sources/APIClient/Mocks.swift
+++ b/Modules/Sources/APIClient/Mocks.swift
@@ -11,8 +11,8 @@ import Model
 
 extension APIClient {
     public static let mock = Self(
-        authenticate: { _, _ in .init(value: .mock) },
-        refreshToken: { _ in .init(value: .mock) },
+        authenticate: { _, _ in .mock },
+        refreshToken: { _ in .mock },
         setToken: { _ in },
         setBaseURL: { _ in },
         currentBaseURL: { URL.init(string: ":")! }

--- a/Modules/Sources/APIClientLive/AuthenticationHandler.swift
+++ b/Modules/Sources/APIClientLive/AuthenticationHandler.swift
@@ -13,7 +13,7 @@ import Model
 /// The state of tokens can be monitored by subscribing to `tokenUpdatePublisher`, if this outouts nil, it means the user should log in again
 public class AuthenticationHandler {
 
-    public let tokenUpdatePublisher: CurrentValueSubject<APITokens?, Never>
+    public let tokenUpdatePublisher: CurrentValueSubject<APITokensEnvelope?, Never>
     var now: () -> Date = Date.init
     var networkRequestPublisher:
         (URLRequest) -> AnyPublisher<
@@ -22,10 +22,10 @@ public class AuthenticationHandler {
             URLSession.shared.dataTaskPublisher(for: $0).eraseToAnyPublisher()
         }
     private let queue = DispatchQueue(label: "Authenticator.\(UUID().uuidString)")
-    private(set) var refreshPublisher: PassthroughSubject<APITokens, Error>?
+    private(set) var refreshPublisher: PassthroughSubject<APITokensEnvelope, Error>?
 
     private var refreshURL: URL
-    var apiTokens: APITokens? {
+    var apiTokens: APITokensEnvelope? {
         didSet {
             if let apiTokens = apiTokens {
                 refreshPublisher?.send(apiTokens)
@@ -38,7 +38,7 @@ public class AuthenticationHandler {
 
     public init(
         refreshURL: URL,
-        tokens: APITokens?
+        tokens: APITokensEnvelope?
     ) {
         self.apiTokens = tokens
         self.tokenUpdatePublisher = CurrentValueSubject(tokens)
@@ -54,9 +54,9 @@ public class AuthenticationHandler {
             > = {
                 URLSession.shared.dataTaskPublisher(for: $0).eraseToAnyPublisher()
             },
-            refreshPublisher: PassthroughSubject<APITokens, Error>? = nil,
+            refreshPublisher: PassthroughSubject<APITokensEnvelope, Error>? = nil,
             refreshURL: URL,
-            apiTokens: APITokens? = nil
+            apiTokens: APITokensEnvelope? = nil
         ) {
             self.tokenUpdatePublisher = CurrentValueSubject(apiTokens)
             self.now = now
@@ -145,7 +145,7 @@ public class AuthenticationHandler {
     /// Make call to refresh access token
     /// - Parameter refreshToken: refreshtoken to be used
     /// - Returns: A fresh set of tokens
-    private func refreshTokens(using refreshToken: RefreshToken) -> AnyPublisher<APITokens, Error> {
+    private func refreshTokens(using refreshToken: RefreshToken) -> AnyPublisher<APITokensEnvelope, Error> {
         struct Body: Encodable {
             let token: String
         }
@@ -168,7 +168,7 @@ public class AuthenticationHandler {
                     return $0.data
                 }
             }
-            .decode(type: APITokens.self, decoder: decoder)
+            .decode(type: APITokensEnvelope.self, decoder: decoder)
             .eraseToAnyPublisher()
     }
 }

--- a/Modules/Sources/APIClientLive/AuthenticationhandlerAsync.swift
+++ b/Modules/Sources/APIClientLive/AuthenticationhandlerAsync.swift
@@ -1,0 +1,157 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jakob Mygind on 14/11/2022.
+//
+
+import Foundation
+import Model
+
+/// This class is used to authenticate all requests, and if needed refresh the tokens
+/// The state of tokens can be monitored by subscribing to `tokenUpdatePublisher`, if this outouts nil, it means the user should log in again
+public actor AuthenticationHandlerAsync {
+    
+    var apiTokens: APITokensEnvelope? {
+        get { getTokens() }
+        set { saveTokens(newValue) }
+    }
+    
+    var refreshTask: Task<APITokensEnvelope, Error>?
+    var networkRequest:
+    (URLRequest) async throws -> (Data, URLResponse) = URLSession.shared.data(for: )
+    var now: () -> Date = Date.init
+    
+    private var refreshURL: URL
+    
+    let getTokens: () -> APITokensEnvelope?
+    let saveTokens: (APITokensEnvelope?) -> Void
+    
+    public init(
+        refreshURL: URL,
+        getTokens: @escaping () -> APITokensEnvelope?,
+        saveTokens: @escaping (APITokensEnvelope?) -> Void,
+        now: @escaping () -> Date = Date.init,
+        networkRequest: @escaping (URLRequest) async throws -> (Data, URLResponse) = URLSession.shared.data(for: )
+    ) {
+        self.refreshURL = refreshURL
+        self.getTokens = getTokens
+        self.saveTokens = saveTokens
+        self.now = now
+        self.networkRequest = networkRequest
+    }
+    
+    func validTokens() async throws -> APITokensEnvelope {
+        if let handle = refreshTask {
+            return try await handle.value
+        }
+        
+        guard let apiTokens else {
+            throw URLError(.userAuthenticationRequired)
+        }
+        
+        if apiTokens.token.isValid(now: now()) {
+            return apiTokens
+        }
+        
+        return try await refreshedTokens()
+    }
+    
+    func refreshedTokens() async throws -> APITokensEnvelope {
+        if let refreshTask = refreshTask {
+            return try await refreshTask.value
+        }
+        
+        let task = Task { () throws -> APITokensEnvelope in
+            defer { refreshTask = nil }
+            
+            guard let refreshToken = apiTokens?.refreshToken else {
+                throw URLError(.userAuthenticationRequired)
+            }
+            let newTokens = try await refreshTokens(using: refreshToken.token)
+            apiTokens = newTokens
+            
+            return newTokens
+        }
+        
+        self.refreshTask = task
+        
+        return try await task.value
+    }
+    
+    /// Authenticates URLRequests
+    /// - Parameter request: Requests to be authenticated
+    /// - Returns: The result of the request
+    public func performAuthenticatedRequest(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        
+        let tokens = try await validTokens()
+        
+        do {
+            let response = try await performAuthenticatedRequest(request, accessToken: tokens.token)
+            if let code = (response.1 as? HTTPURLResponse)?.statusCode,
+               code == 401
+            {
+                throw URLError(.userAuthenticationRequired)
+            }
+            return response
+        } catch let error as URLError where error.code == .userAuthenticationRequired {
+            let freshTokens = try await refreshTokens(using: tokens.refreshToken.token)
+            let response = try await performAuthenticatedRequest(request, accessToken: freshTokens.token)
+            return response
+        }
+    }
+    
+    /// Adds access token to request
+    /// throws auth error if provided token should be invalid
+    private func performAuthenticatedRequest(
+        _ request: URLRequest,
+        accessToken: AccessToken
+    ) async throws -> (Data, URLResponse) {
+        var request = request
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        return try await networkRequest(request)
+    }
+    
+    /// Make call to refresh access token
+    /// - Parameter refreshToken: refreshtoken to be used
+    /// - Returns: A fresh set of tokens
+    private func refreshTokens(using refreshToken: RefreshToken) async throws -> APITokensEnvelope {
+        struct Body: Encodable {
+            let token: String
+        }
+        
+        let decoder = JSONDecoder()
+        
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
+        decoder.dateDecodingStrategy = .formatted(formatter)
+        
+        var request = URLRequest(url: refreshURL)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(Body(token: refreshToken.rawValue))
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let response = try await networkRequest(request)
+        if let code = (response.1 as? HTTPURLResponse)?.statusCode,
+           code == 401
+        {
+            self.apiTokens = nil
+            throw URLError(.userAuthenticationRequired)
+        }
+        
+        return try decoder.decode(APITokensEnvelope.self, from: response.0)
+    }
+}
+
+//#if !RELEASE
+//extension AccessToken {
+//    /// A token with expiry some time in December afair
+//    public static let expired = AccessToken(
+//        rawValue:
+//            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMyIsInRva2VuVHlwZSI6Ik1lcmNoYW50IiwibmJmIjoxNjM5NTg0OTUyLCJleHAiOjE2Mzk1ODYxNTIsImlhdCI6MTYzOTU4NDk1Mn0.X2w58Hk8Wtct3-PHYqPLGmCsUgrPuLcp9-hw98E4ZCM"
+//    )
+//}
+//#endif
+

--- a/Modules/Sources/AppFeature/AppEnvironment.swift
+++ b/Modules/Sources/AppFeature/AppEnvironment.swift
@@ -25,7 +25,7 @@ public struct AppEnvironment {
     var localizations: ObservableLocalizations
     var appVersion: AppVersion
     var persistenceClient: PersistenceClient
-    var tokenUpdatePublisher: AnyPublisher<APITokens?, Never>
+    var tokenUpdatePublisher: AnyPublisher<APITokensEnvelope?, Never>
     var networkMonitor: NetworkClient
 
     public init(
@@ -36,7 +36,7 @@ public struct AppEnvironment {
         localizations: ObservableLocalizations,
         appVersion: AppVersion,
         persistenceClient: PersistenceClient,
-        tokenUpdatePublisher: AnyPublisher<APITokens?, Never>,
+        tokenUpdatePublisher: AnyPublisher<APITokensEnvelope?, Never>,
         networkMonitor: NetworkClient
     ) {
         self.mainQueue = mainQueue

--- a/Modules/Sources/LoginFeature/LoginViewModel.swift
+++ b/Modules/Sources/LoginFeature/LoginViewModel.swift
@@ -13,7 +13,7 @@ import Style
 public class LoginViewModel: ObservableObject {
 
     var environment: LoginEnvironment
-    var onSuccess: (APITokens, Username) -> Void
+    var onSuccess: (APITokensEnvelope, Username) -> Void
 
     enum Route {
         case alert(AlertState)
@@ -29,7 +29,7 @@ public class LoginViewModel: ObservableObject {
     var cancellables: Set<AnyCancellable> = []
 
     public init(
-        onSuccess: @escaping (APITokens, Username) -> Void,
+        onSuccess: @escaping (APITokensEnvelope, Username) -> Void,
         environment: LoginEnvironment
     ) {
         self.environment = environment

--- a/Modules/Sources/Model/APITokensEnvelope.swift
+++ b/Modules/Sources/Model/APITokensEnvelope.swift
@@ -24,7 +24,7 @@ public struct RefreshTokenEnvelope: Codable, Equatable {
     public var expiresAt: Date
 }
 
-public struct APITokens: Codable, Equatable {
+public struct APITokensEnvelope: Codable, Equatable {
     init(
         token: AccessToken,
         refreshToken: RefreshTokenEnvelope
@@ -37,7 +37,7 @@ public struct APITokens: Codable, Equatable {
     public var refreshToken: RefreshTokenEnvelope
 }
 
-extension APITokens {
+extension APITokensEnvelope {
     public static let mock = Self(
         token: "MockToken",
         refreshToken: .init(token: "MockRefreshToken", expiresAt: .distantFuture))

--- a/Modules/Sources/PersistenceClient/Client.swift
+++ b/Modules/Sources/PersistenceClient/Client.swift
@@ -10,6 +10,6 @@ import Model
 
 /// Client used for storing data
 public struct PersistenceClient {
-    public var tokens: FileClient<APITokens>
+    public var tokens: FileClient<APITokensEnvelope>
     public var email: FileClient<Username>
 }

--- a/Modules/Tests/APIClientLiveTests/APIClientAsyncLiveTests.swift
+++ b/Modules/Tests/APIClientLiveTests/APIClientAsyncLiveTests.swift
@@ -1,0 +1,183 @@
+import Combine
+import Foundation
+import XCTest
+
+//
+//  File.swift
+//
+//
+//  Created by Jakob Mygind on 20/01/2022.
+//
+@testable import APIClientLive
+@testable import Model
+
+final class APIClientAsyncLiveTests: XCTestCase {
+
+    var formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
+        return formatter
+    }()
+
+    let tokenSuccessResponseData = """
+        {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiOSIsInRva2VuVHlwZSI6Ik1lcmNoYW50IiwibmJmIjoxNjQyNjgxMzU1LCJleHAiOjE2NDI2ODI1NTUsImlhdCI6MTY0MjY4MTM1NX0.TUt15w5BOJfeekhM4TY0qdCHNlr4qtDIVdh_S6MzwTI",
+            "refreshToken": {
+                "token": "6/IOyrlaxkYSI/hqVrDFgzn2tefXfKrVNQJvEIJ32gMhDDNAkmDMYiNogS4LvdS3r3CLuRqbiWWNLcTby3i9xg==",
+                "expiresAt": "2022-04-20T12:22:35.3876411Z"
+            }
+        }
+        """.data(using: .utf8)!
+
+    lazy var newTokens = APITokensEnvelope(
+        token: .init(
+            rawValue:
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiOSIsInRva2VuVHlwZSI6Ik1lcmNoYW50IiwibmJmIjoxNjQyNjgxMzU1LCJleHAiOjE2NDI2ODI1NTUsImlhdCI6MTY0MjY4MTM1NX0.TUt15w5BOJfeekhM4TY0qdCHNlr4qtDIVdh_S6MzwTI"
+        ),
+        refreshToken: .init(
+            token: .init(
+                rawValue:
+                    "6/IOyrlaxkYSI/hqVrDFgzn2tefXfKrVNQJvEIJ32gMhDDNAkmDMYiNogS4LvdS3r3CLuRqbiWWNLcTby3i9xg=="
+            ),
+            expiresAt: formatter.date(from: "2022-04-20T12:22:35.3876411Z")!
+        )
+    )
+    
+    let apiCallSuccessData = "Success".data(using: .utf8)!
+
+    @available(iOS 16.0, *)
+    @MainActor
+    func test_refreshing_expired_token() async throws {
+        let successResponse = HTTPURLResponse(
+            url: URL(string: ":")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let now = Date.distantFuture
+        var tokens: APITokensEnvelope? = APITokensEnvelope.mock
+
+        tokens?.token = .expired
+
+        let apiURLRequest: URLRequest = URLRequest(url: URL(string: ":")!)
+        let refreshURL = URL(string: "refresh://")!
+        
+        var continuation: CheckedContinuation<(Data, URLResponse), Error>!
+        
+        var requestsMade: [URLRequest] = []
+        let authHandler = AuthenticationHandlerAsync(
+            refreshURL: refreshURL,
+            getTokens: { tokens },
+            saveTokens: { tokens = $0 },
+            now: { now },
+            networkRequest: { urlRequest in
+                requestsMade.append(urlRequest)
+                return try await withCheckedThrowingContinuation({ cont in
+                    continuation = cont
+                })
+            })
+
+        var valuesReceived: [URLSession.DataTaskPublisher.Output] = []
+
+        var task = await authHandler.refreshTask
+        XCTAssertNil(task) // Not yet refreshing
+        Task {
+            do {
+                valuesReceived.append(try await authHandler.performAuthenticatedRequest(apiURLRequest))  // Make the api call
+            } catch {
+                XCTFail()
+            }
+        }
+
+        await Task.yield()
+        task = await authHandler.refreshTask
+        XCTAssertNotNil(task)  // Refresh started
+        XCTAssertEqual(requestsMade.count, 1)
+        XCTAssertEqual(requestsMade.first?.url, refreshURL)  // Refreash call was made
+        continuation.resume(returning: (tokenSuccessResponseData, successResponse))
+
+        try await Task.sleep(for: .milliseconds(1))
+        task = await authHandler.refreshTask
+        XCTAssertNil(task)  // Refresh ended
+        
+        let refreshedTokens = await authHandler.apiTokens
+        XCTAssertEqual(refreshedTokens, newTokens)  // We now have new tokens
+        continuation.resume(returning: (apiCallSuccessData, successResponse)) // Now original api call is made and for convenience we just send the same data again
+        try await Task.sleep(for: .milliseconds(1))
+
+        task = await authHandler.refreshTask
+        XCTAssertNil(task)  // Refresh was terminated
+        XCTAssertEqual(valuesReceived.count, 1)
+        let result = try XCTUnwrap(valuesReceived.first)
+        XCTAssertEqual(result.data, apiCallSuccessData)  // Original api call successfully returned some data
+    }
+
+    @available(iOS 16.0, *)
+    @MainActor
+    func test_refreshing_expired_token_while_multiple_calls_made() async throws {
+        let successResponse = HTTPURLResponse(
+            url: URL(string: ":")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let now = Date.distantFuture
+        var tokens: APITokensEnvelope? = APITokensEnvelope.mock
+
+        tokens?.token = .expired
+
+        let apiURLRequest: URLRequest = URLRequest(url: URL(string: ":")!)
+        let refreshURL = URL(string: "refresh://")!
+        
+        var continuations: [CheckedContinuation<(Data, URLResponse), Error>] = []
+        
+        var requestsMade: [URLRequest] = []
+        let authHandler = AuthenticationHandlerAsync(
+            refreshURL: refreshURL,
+            getTokens: { tokens },
+            saveTokens: { tokens = $0 },
+            now: { now },
+            networkRequest: { urlRequest in
+                requestsMade.append(urlRequest)
+                return try await withCheckedThrowingContinuation({ cont in
+                    continuations.append(cont)
+                })
+            })
+
+        var valuesReceived: [URLSession.DataTaskPublisher.Output] = []
+
+        var task = await authHandler.refreshTask
+        XCTAssertNil(task) // Not yet refreshing
+        
+        for _ in 0..<3 {
+            Task {
+                do {
+                    valuesReceived.append(try await authHandler.performAuthenticatedRequest(apiURLRequest))  // Make the api call
+                } catch {
+                    XCTFail()
+                }
+            }
+        }
+
+        await Task.yield()
+        task = await authHandler.refreshTask
+        XCTAssertNotNil(task)  // Refresh started
+        XCTAssertEqual(requestsMade.count, 1)
+        XCTAssertEqual(requestsMade.first?.url, refreshURL)  // Refreash call was made
+        (try XCTUnwrap(continuations.removeFirst())).resume(returning: (tokenSuccessResponseData, successResponse))
+    
+        try await Task.sleep(for: .milliseconds(1))
+        task = await authHandler.refreshTask
+        XCTAssertNil(task)  // Refresh ended
+        XCTAssertEqual(continuations.count, 3)
+        let refreshedTokens = await authHandler.apiTokens
+        XCTAssertEqual(refreshedTokens, newTokens)  // We now have new tokens
+        try await Task.sleep(for: .milliseconds(1))
+        continuations.forEach {
+            $0.resume(returning: (apiCallSuccessData, successResponse))
+        }
+
+        try await Task.sleep(for: .milliseconds(1))
+
+        task = await authHandler.refreshTask
+        XCTAssertNil(task)  // Refresh was terminated
+        XCTAssertEqual(valuesReceived.count, 3)
+        let result = try XCTUnwrap(valuesReceived.first)
+        XCTAssertEqual(result.data, apiCallSuccessData)  // Original api call successfully returned some data
+    }
+
+}
+

--- a/Modules/Tests/APIClientLiveTests/APIClientLiveTests.swift
+++ b/Modules/Tests/APIClientLiveTests/APIClientLiveTests.swift
@@ -30,7 +30,7 @@ final class APIClientLiveTests: XCTestCase {
         }
         """.data(using: .utf8)!
 
-    lazy var newTokens = APITokens(
+    lazy var newTokens = APITokensEnvelope(
         token: .init(
             rawValue:
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiOSIsInRva2VuVHlwZSI6Ik1lcmNoYW50IiwibmJmIjoxNjQyNjgxMzU1LCJleHAiOjE2NDI2ODI1NTUsImlhdCI6MTY0MjY4MTM1NX0.TUt15w5BOJfeekhM4TY0qdCHNlr4qtDIVdh_S6MzwTI"
@@ -50,7 +50,7 @@ final class APIClientLiveTests: XCTestCase {
         let successResponse = HTTPURLResponse(
             url: URL(string: ":")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
         let now = Date.distantFuture
-        var tokens = APITokens.mock
+        var tokens = APITokensEnvelope.mock
 
         tokens.token = .expired
         let networkPublisherSubject = PassthroughSubject<
@@ -102,7 +102,7 @@ final class APIClientLiveTests: XCTestCase {
         let successResponse = HTTPURLResponse(
             url: URL(string: ":")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
         let now = Date.distantFuture
-        var tokens = APITokens.mock
+        var tokens = APITokensEnvelope.mock
 
         tokens.token = .expired
         let networkPublisherSubject = PassthroughSubject<


### PR DESCRIPTION
This PR adds an async version of the existing token refresh mechanism including unit tests verifying 
1. A single api call with expired token refreshes tokens and subsequently completes the API call
2. Several API calls being fired simultaneously with an expired token resulting in a single refresh and api calls finally completing

Still needs tests for refresh failing and such